### PR TITLE
black-compatible ruff config

### DIFF
--- a/exports/__init__.py
+++ b/exports/__init__.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-_T = TypeVar('_T', bound='Callable[..., object] | type | object')
-_V = TypeVar('_V')
+_T = TypeVar("_T", bound="Callable[..., object] | type | object")
+_V = TypeVar("_V")
 
 _lock: Final = _thread.RLock()
 
@@ -75,7 +75,7 @@ def export(obj: _T | str, /, *, threadsafe: bool = False) -> Callable[[_T], _T] 
     """
     module = inspect.getmodule(inspect.stack()[1][0])
     if module is None:
-        raise ModuleNotFoundError(f'could not find module of {obj!r}')
+        raise ModuleNotFoundError(f"could not find module of {obj!r}")
 
     res: Callable[[_T], _T] | _T
     name: str
@@ -84,12 +84,12 @@ def export(obj: _T | str, /, *, threadsafe: bool = False) -> Callable[[_T], _T] 
         res = _identity
     else:
         res = obj
-        name = cast('str', getattr(obj, '__name__', None)) or str(obj)
+        name = cast("str", getattr(obj, "__name__", None)) or str(obj)
 
     with _lock if threadsafe else contextlib.nullcontext():
-        exports = list(cast('list[str]', getattr(module, '__all__', [])))
+        exports = list(cast("list[str]", getattr(module, "__all__", [])))
         if name in exports:
-            warnings.warn(f'{name!r} already exported', stacklevel=2)
+            warnings.warn(f"{name!r} already exported", stacklevel=2)
         else:
             exports.append(name)
         module.__all__ = exports  # type: ignore[attr-defined]  # pyright: ignore[reportAttributeAccessIssue]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,13 @@ dev = [
   "sp-repo-review[cli]>=2025.11.21",
 ]
 
+# codespell
+
 [tool.codespell]
 skip = '*.lock,.venv,.vscode,dist'
 context = 2
+
+# mypy
 
 [tool.mypy]
 strict = true
@@ -62,6 +66,8 @@ local_partial_types = true
 warn_unreachable = false
 warn_unused_ignores = true
 
+# (based)pyright
+
 [tool.pyright]
 include = ["exports", "tests"]
 exclude = [".venv"]
@@ -69,6 +75,8 @@ stubPath = "."
 pythonPlatform = "All"
 typeCheckingMode = "all"
 reportUnusedCallResult = false # https://github.com/microsoft/pyright/issues/8650
+
+# pytest
 
 [tool.pytest.ini_options]
 minversion = "9.0"
@@ -78,17 +86,21 @@ filterwarnings = ["error"]
 log_level = "INFO"
 strict = true
 
+# repo-review
+
 [tool.repo-review]
 ignore = ["PY004", "PY006", "RTD"]
+
+# ruff
 
 [tool.ruff]
 src = ["exports"]
 show-fixes = true
 force-exclude = true
 extend-exclude = [".github", ".vscode", "tests"]
+preview = true
 
 [tool.ruff.lint]
-preview = true
 select = ["ALL"]
 ignore = ["CPY", "DOC", "EM102", "TRY003", "D104", "RUF067"]
 
@@ -98,19 +110,16 @@ combine-as-imports = true
 known-first-party = ["exports"]
 lines-after-imports = 2
 lines-between-types = 0
+split-on-trailing-comma = false
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.lint.flake8-quotes]
-inline-quotes = "single"
-
 [tool.ruff.format]
-preview = true
-quote-style = "single"
-# keep in sync with .editorconfig
-indent-style = "space"
 line-ending = "lf"
+skip-magic-trailing-comma = true
+
+# tox
 
 [tool.tox]
 min_version = "4"


### PR DESCRIPTION
double quotes and ignore trailing commas

this also makes the pyproject.toml a bit less annoying to mentally parse using some tactical comments