### PR TITLE
fix ci test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,14 +55,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        py: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v6.0.1
 
       - uses: astral-sh/setup-uv@v7.2.0
         with:
-          enable-cache: true
+          python-version: ${{ matrix.py }}
 
       - name: pytest
         run: uv run pytest


### PR DESCRIPTION
uv wasn't using the py version from the matrix